### PR TITLE
feat(utils-date): remove spaces in `formatMilliseconds` output (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ coverage
 node_modules
 dist
 .DS_Store
+.vscode
+.idea

--- a/src/utils-date/__tests__/format.test.ts
+++ b/src/utils-date/__tests__/format.test.ts
@@ -111,33 +111,33 @@ describe('date', () => {
 
   describe('format milliseconds', () => {
     it('should format to milliseconds when less than 1 second', () => {
-      expect(formatMilliseconds(0)).toBe('0 ms');
-      expect(formatMilliseconds(300)).toBe('300 ms');
-      expect(formatMilliseconds(999)).toBe('999 ms');
+      expect(formatMilliseconds(0)).toBe('0ms');
+      expect(formatMilliseconds(300)).toBe('300ms');
+      expect(formatMilliseconds(999)).toBe('999ms');
     });
 
     it('should format to seconds when >= 1 second and < 1 minute', () => {
-      expect(formatMilliseconds(1000)).toBe('1 s');
-      expect(formatMilliseconds(45000)).toBe('45 s');
-      expect(formatMilliseconds(59999)).toBe('59 s');
+      expect(formatMilliseconds(1000)).toBe('1s');
+      expect(formatMilliseconds(45000)).toBe('45s');
+      expect(formatMilliseconds(59999)).toBe('59s');
     });
 
     it('should format to minutes and seconds when >= 1 minute and < 1 hour', () => {
-      expect(formatMilliseconds(60000)).toBe('1 m 0 s');
-      expect(formatMilliseconds(100000)).toBe('1 m 40 s');
-      expect(formatMilliseconds(3599999)).toBe('59 m 59 s');
+      expect(formatMilliseconds(60000)).toBe('1m0s');
+      expect(formatMilliseconds(100000)).toBe('1m40s');
+      expect(formatMilliseconds(3599999)).toBe('59m59s');
     });
 
     it('should format to hours and minutes when >= 1 hour and < 1 day', () => {
-      expect(formatMilliseconds(3600000)).toBe('1 h 0 m');
-      expect(formatMilliseconds(5400000)).toBe('1 h 30 m');
-      expect(formatMilliseconds(86399999)).toBe('23 h 59 m');
+      expect(formatMilliseconds(3600000)).toBe('1h0m');
+      expect(formatMilliseconds(5400000)).toBe('1h30m');
+      expect(formatMilliseconds(86399999)).toBe('23h59m');
     });
 
     it('should format to days and hours when >= 1 day', () => {
-      expect(formatMilliseconds(86400000)).toBe('1 d 0 h');
-      expect(formatMilliseconds(90000000)).toBe('1 d 1 h');
-      expect(formatMilliseconds(180000000)).toBe('2 d 2 h');
+      expect(formatMilliseconds(86400000)).toBe('1d0h');
+      expect(formatMilliseconds(90000000)).toBe('1d1h');
+      expect(formatMilliseconds(180000000)).toBe('2d2h');
     });
   });
 });

--- a/src/utils-date/format.ts
+++ b/src/utils-date/format.ts
@@ -104,25 +104,25 @@ export const formatMilliseconds = (ms: number): string => {
   if (ms >= MS_PER_DAY) {
     const days = Math.floor(ms / MS_PER_DAY);
     const hours = Math.floor((ms % MS_PER_DAY) / MS_PER_HOUR);
-    return `${days} d ${hours} h`;
+    return `${days}d${hours}h`;
   }
 
   if (ms >= MS_PER_HOUR) {
     const hours = Math.floor(ms / MS_PER_HOUR);
     const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
-    return `${hours} h ${minutes} m`;
+    return `${hours}h${minutes}m`;
   }
 
   if (ms >= MS_PER_MINUTE) {
     const minutes = Math.floor(ms / MS_PER_MINUTE);
     const seconds = Math.floor((ms % MS_PER_MINUTE) / MS_PER_SECOND);
-    return `${minutes} m ${seconds} s`;
+    return `${minutes}m${seconds}s`;
   }
 
   if (ms >= MS_PER_SECOND) {
     const seconds = Math.floor(ms / MS_PER_SECOND);
-    return `${seconds} s`;
+    return `${seconds}s`;
   }
 
-  return `${ms} ms`;
+  return `${ms}ms`;
 };


### PR DESCRIPTION
Closes #43